### PR TITLE
Improve BellDisplay tests

### DIFF
--- a/src/component/BellDisplay.spec.tsx
+++ b/src/component/BellDisplay.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { render, getByRole, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import BellDisplay from './BellDisplay';
+
+import MobileCheck from '../util/MobileCheck';
+
+jest.mock('../util/MobileCheck');
 
 describe('BellDisplay component', () => {
   test('should render without crash', () => {
@@ -28,6 +32,11 @@ describe('BellDisplay component', () => {
     expect(elem.getAttribute('alt')).toBe(expectedAlt);
   });
   test('should display tooltip with bell units and bell amount on mouse hover (desktop)', () => {
+    const mockNonMobile = jest.fn();
+    mockNonMobile.mockReturnValue(false);
+
+    MobileCheck.isMobile = mockNonMobile;
+
     const expectedAmount: number = 12;
     const expectedUnits: number = 1000;
 
@@ -45,6 +54,11 @@ describe('BellDisplay component', () => {
     );
   });
   test('should display tooltip with quantity and bell amount on tap (mobile)', () => {
+    const mockMobile = jest.fn();
+    mockMobile.mockReturnValue(true);
+
+    MobileCheck.isMobile = mockMobile;
+
     const expectedAmount: number = 12;
     const expectedUnits: number = 1000;
 
@@ -54,12 +68,15 @@ describe('BellDisplay component', () => {
 
     const topElem = getByText(expectedAmount.toString());
     expect(topElem).toBeTruthy();
-    // TODO change user agent to mobile but desktop can still tap so may not be required
+
     fireEvent.click(topElem);
     const tooltip = getByText(`${expectedAmount} stacks of`);
     expect(tooltip).toBeTruthy();
     expect(tooltip.textContent).toBe(
       `${expectedAmount} stacks of ${expectedUnits} bells`,
     );
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 });


### PR DESCRIPTION
Add mocks to two of the tests in `BellDisplay` to more accurately test expectations of desktop and mobile tooltips.