### PR TITLE
Round tips to nearest hundredth

### DIFF
--- a/src/component/TurnipCalculator.spec.tsx
+++ b/src/component/TurnipCalculator.spec.tsx
@@ -129,4 +129,55 @@ describe('TurnipCalculator component', () => {
 
     expect(handler).toHaveBeenLastCalledWith(expectedTip);
   });
+  test('should round tips to nearest hundredth', () => {
+    const handler = jest.fn();
+
+    const { getByRole } = render(
+      <TurnipCalculator onTipCalculated={handler} />,
+    );
+
+    const priceField = getByRole('textbox', {
+      name: 'price',
+    });
+    const turnipsField = getByRole('textbox', {
+      name: 'turnips',
+    });
+    const tipField = getByRole('textbox', {
+      name: 'tip_percent',
+    });
+
+    fireEvent.change(priceField, {
+      target: {
+        value: 100,
+      },
+    });
+    fireEvent.change(turnipsField, {
+      target: {
+        value: 104,
+      },
+    });
+    fireEvent.change(tipField, {
+      target: {
+        value: 10,
+      },
+    });
+    expect(handler).toHaveBeenLastCalledWith(1000);
+
+    fireEvent.change(priceField, {
+      target: {
+        value: 100,
+      },
+    });
+    fireEvent.change(turnipsField, {
+      target: {
+        value: 106,
+      },
+    });
+    fireEvent.change(tipField, {
+      target: {
+        value: 10,
+      },
+    });
+    expect(handler).toHaveBeenLastCalledWith(1100);
+  });
 });

--- a/src/component/TurnipCalculator.tsx
+++ b/src/component/TurnipCalculator.tsx
@@ -9,6 +9,8 @@ export default function TurnipCalculator(props: any) {
   const [tipPercent, setTipPercent] = useState(10);
   const [tip, setTip] = useState(0);
 
+  const ROUND_TO_NEAREST: number = 100;
+
   const { onPriceCalculated, onTipCalculated } = props;
   const inputStyle = css`
     padding: 12px;
@@ -26,7 +28,10 @@ export default function TurnipCalculator(props: any) {
   }, [price, turnips]);
 
   useEffect(() => {
-    setTip(buyPrice * (tipPercent / 100));
+    setTip(
+      Math.round((buyPrice * (tipPercent / 100)) / ROUND_TO_NEAREST) *
+        ROUND_TO_NEAREST,
+    );
   }, [buyPrice, tipPercent]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #44. To my knowledge, players can only give bells to other players by splitting from their bell count, and the lowest denominator they can split by is 100. Therefore, it makes sense to only show tip amount rounded to nearest hundredth.