### PR TITLE
Show only one tooltip at a time on mobile

### DIFF
--- a/src/component/BellDisplay.tsx
+++ b/src/component/BellDisplay.tsx
@@ -1,30 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { css } from 'emotion';
 import MobileCheck from '../util/MobileCheck';
 
 export default function BellDisplay(props: any) {
-  const { amount, imgSrc, alt, bellUnits } = props;
+  const { amount, imgSrc, alt, bellUnits, tooltipName, shownTooltipName, setShownTooltipName } = props;
+  const showTooltip = tooltipName === shownTooltipName;
 
-  const [showTooltip, setShowTooltip] = useState(false);
-
-  const tooltip = showTooltip ? (
-    <div
-      className={css`
-        position: absolute;
-        border: 1px solid black;
-        border-radius: 16px;
-        background-color: goldenrod;
-        padding: 8px;
-        font-size: 16px;
-      `}
-    >
-      {(() => `${amount} stack${amount !== 1 ? 's' : ''} of `)()}
-      <b>{bellUnits} bells</b>
-    </div>
-  ) : (
-    <></>
-  );
+  function setShowTooltip(show: boolean) {
+    setShownTooltipName(show ? tooltipName : "");
+  }
 
   if (amount === 0) {
     return <></>;
@@ -57,7 +42,21 @@ export default function BellDisplay(props: any) {
         title={bellUnits + ' bells'}
       />
       {amount}
-      {tooltip}
+      {showTooltip && (
+        <div
+          className={css`
+            position: absolute;
+            border: 1px solid black;
+            border-radius: 16px;
+            background-color: goldenrod;
+            padding: 8px;
+            font-size: 16px;
+          `}
+        >
+          {`${amount} stack${amount !== 1 ? 's' : ''} of `}
+          <b>{bellUnits} bells</b>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/component/TipDisplay.spec.tsx
+++ b/src/component/TipDisplay.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import TipDisplay from './TipDisplay';
 
 import MobileCheck from '../util/MobileCheck';
@@ -65,6 +65,37 @@ describe('TipDisplay component', () => {
     const hoverMessage = getByText(/tap/i);
     expect(hoverMessage.textContent).toContain('icons');
     expect(hoverMessage.textContent).toContain('quantities');
+  });
+  test('should show only one tooltip at a time on mobile', () => {
+    const mockMobile = jest.fn();
+    mockMobile.mockReturnValue(true);
+
+    MobileCheck.isMobile = mockMobile;
+
+    const { getByAltText, getAllByText, queryAllByText } = render(<TipDisplay tip={11000 * 2} />);
+    const mediumBellBagIcon = getByAltText('Medium Bell Bag Icon');
+    const smallBellBagIcon = getByAltText('Small Bell Bag Icon');
+
+    // initially, there should be no tooltips shown
+    expect(queryAllByText(/stacks/i)).toHaveLength(0);
+
+    // show  medium bell bags tooltip
+    fireEvent.click(mediumBellBagIcon);
+
+    const mediumBellBagTooltip = getAllByText(/stacks/i);
+    expect(mediumBellBagTooltip).toHaveLength(1);
+
+    // show small bell bags tooltip
+    fireEvent.click(smallBellBagIcon);
+
+    const smallBellBagTooltip = getAllByText(/stacks/i);
+    expect(smallBellBagTooltip).toHaveLength(1);
+
+    // hide small bell bags tooltip
+    fireEvent.click(smallBellBagIcon);
+
+    // no tooltip should be shown
+    expect(queryAllByText(/stacks/i)).toHaveLength(0);
   });
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/component/TipDisplay.tsx
+++ b/src/component/TipDisplay.tsx
@@ -14,6 +14,7 @@ export default function TipDisplay(props: any) {
   const [smallBags, setSmallBags] = useState(0);
   const [mediumBags, setMediumBags] = useState(0);
   const [largeBags, setLargeBags] = useState(0);
+  const [shownTooltipName, setShownTooltipName] = useState("");
 
   useEffect(() => {
     let workingTip = tip;
@@ -47,31 +48,43 @@ export default function TipDisplay(props: any) {
         If you want to provide a tip, then tip: <b>{tip}</b> bells
       </label>
       <br />
-      <span>Thats...</span>
+      <span>That's...</span>
       <br />
       <BellDisplay
         amount={largeBags}
         imgSrc={largeBellImg}
         alt={'Large Bell Bag Icon'}
         bellUnits={99000}
+        tooltipName="largeBags"
+        shownTooltipName={shownTooltipName}
+        setShownTooltipName={setShownTooltipName}
       />
       <BellDisplay
         amount={mediumBags}
         imgSrc={mediumBellImg}
         alt={'Medium Bell Bag Icon'}
         bellUnits={10000}
+        tooltipName="mediumBags"
+        shownTooltipName={shownTooltipName}
+        setShownTooltipName={setShownTooltipName}
       />
       <BellDisplay
         amount={smallBags}
         imgSrc={smallBellImg}
         alt={'Small Bell Bag Icon'}
         bellUnits={1000}
+        tooltipName="smallBags"
+        shownTooltipName={shownTooltipName}
+        setShownTooltipName={setShownTooltipName}
       />
       <BellDisplay
         amount={coins}
         imgSrc={coinImg}
         alt={'Coin Icon'}
         bellUnits={100}
+        tooltipName="coins"
+        shownTooltipName={shownTooltipName}
+        setShownTooltipName={setShownTooltipName}
       />
       <br />
       <span>


### PR DESCRIPTION
~This fixes issue #43~
Fixes #43

The main change around this was to introduce some shared state in the parent component `TipDisplay`, since each `BellDisplay` needs to know whether to show its respective tooltip.

Also, I noticed you are using TypeScript but not taking full advantage of it. If you are open to it, I have some suggestions to improve your component interfaces. For example, you can create a type for each component's props instead of always using `any`. This makes your components easier to use. I didn't do anything related to this idea on this PR to avoid overcomplicating it.  :)

Do let me know if anything regarding the feature can be improved.