### PR TITLE
Fix broken FormInputField tests

### DIFF
--- a/src/component/form/FormInputField.spec.tsx
+++ b/src/component/form/FormInputField.spec.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import FormInputField from './FormInputField';
 
 describe('FormInputField component', () => {
   test('should render without crash', () => {
-    render(<FormInputField />);
+    render(<FormInputField input={<input></input>} />);
   });
   test('should render label with supplied label text', () => {
     const labelText = 'Test Label';
 
-    const { container } = render(<FormInputField label={labelText} />);
+    const { container } = render(
+      <FormInputField label={labelText} input={<input></input>} />,
+    );
 
     const labelElem = container.querySelector('label');
     expect(labelElem).toHaveTextContent(labelText);

--- a/src/component/form/FormInputField.tsx
+++ b/src/component/form/FormInputField.tsx
@@ -2,8 +2,14 @@ import React from 'react';
 
 import { css } from 'emotion';
 
-export default function FormInputField(props: any) {
-  const { label, input, inputmode = 'decimal' } = props;
+interface Props {
+  input: JSX.Element;
+  label?: string;
+  inputMode?: string;
+}
+
+export default function FormInputField(props: Props) {
+  const { label, input, inputMode = 'decimal' } = props;
 
   return (
     <div
@@ -29,7 +35,7 @@ export default function FormInputField(props: any) {
       >
         {label}
       </label>
-      {React.cloneElement(input, { inputmode })}
+      {React.cloneElement(input, { inputMode })}
     </div>
   );
 }


### PR DESCRIPTION
Unfortunately some tests broke as a result of #54, and this is because `input` is now expected to be present due to the use of `React.cloneElement` to add `inputMode`. Fixed up the tests and added a prop type, which can be used as a reference for #57.